### PR TITLE
Set environment variable SteamClientLaunch to 1

### DIFF
--- a/sfse_loader/main.cpp
+++ b/sfse_loader/main.cpp
@@ -176,6 +176,7 @@ int main(int argc, char ** argv)
 
 		// set this no matter what to work around launch issues
 		SetEnvironmentVariable("SteamGameId", kAppID);
+		SetEnvironmentVariable("SteamClientLaunch", "1");
 
 		if(g_options.m_skipLauncher)
 		{


### PR DESCRIPTION
**Description**
This is a very simple PR to set the environment variable `SteamClientLaunch` to 1 before launching the game, so that achievements can trigger.

**What happened?**
While working on the "The Stars My Destination" achievement which requires visiting all 120 Star Systems, the achievement didn't trigger upon visiting the final system. I discovered that launching the game through Steam directly correctly triggered the achievement, but not via MO2 with SFSE, despite using the [Baka Achievement Enabler](https://www.nexusmods.com/starfield/mods/658) plugin.

I compared the environment variables set when launching via Steam with those when launching via SFSE using [Process Explorer](https://learn.microsoft.com/sysinternals/downloads/process-explorer).
After multiple rebuilds of sfse_loader, removing the achievement using [Steam Achievement Manager](https://github.com/gibbed/SteamAchievementManager), and a process of elimination, I finally isolated the missing variable: SteamClientLaunch.

Hopefully this is all it takes to trigger achievements, but at least in my case it works. 🙂

**Reproduction Steps**
1) Download and extract my [savegame](https://github.com/ianpatt/sfse/files/12553256/Quicksave0_57AB718E_456C656E6120566578_011521_20230907200307_35_0_4.zip) to `%UserProfile%\Documents\My Games\Starfield\Saves`.
2) Start the game and load the quicksave.
3) Grav jump to Van Maanen's Star ([Screenshot of the location](https://github.com/ianpatt/sfse/assets/96642047/181918bc-a418-497e-bb71-a8438f35e86b))
4) After the jump, it should automatically unlock "The Stars My Destination".
