### PR TITLE
Adjust func length for 1.7.36.

### DIFF
--- a/sfse/Hooks_Data.cpp
+++ b/sfse/Hooks_Data.cpp
@@ -9,7 +9,7 @@
 #include "sfse/GameSettings.h"
 #endif
 
-RelocAddr <uintptr_t> GameDataLoad_Target(0x023EF7F0 + 0x1058); // End of this function before the retn
+RelocAddr <uintptr_t> GameDataLoad_Target(0x023EF7F0 + 0x1063); // End of this function before the retn
 
 void Hook_GameData_Loaded()
 {


### PR DESCRIPTION
The latest 1.7.36 update breaks in release mode but not in debug mode and correcting the function length for the game data loaded hook fixes the crash in release mode.