### PR TITLE
improve serialization stability

### DIFF
--- a/sfse/Hooks_Serialization.cpp
+++ b/sfse/Hooks_Serialization.cpp
@@ -87,7 +87,6 @@ bool VM_LoadGame_Hook(void* a_this, void* a_storage, void* a_handleReaderWriter,
 
 void Hooks_Serialization_Apply()
 {
-#if 0
 	// write call hooks for SaveGame, LoadGame & DeleteSaveFile
 	g_branchTrampoline.write5Call(SaveGame_Call.getUIntPtr(), (uintptr_t)SaveGame_Hook);
 	g_branchTrampoline.write5Call(LoadGame_Call.getUIntPtr(), (uintptr_t)LoadGame_Hook);
@@ -107,5 +106,4 @@ void Hooks_Serialization_Apply()
 	safeWrite64(VM_SaveGame_VFunc, (uintptr_t)VM_SaveGame_Hook);
 	safeWrite64(VM_LoadGame_VFunc, (uintptr_t)VM_LoadGame_Hook);
 	safeWrite64(VM_DropAllRunningData_VFunc, (uintptr_t)VM_DropAllRunningData_Hook);
-#endif
 }


### PR DESCRIPTION
This PR adds a few extra safety mechanisms to the serialization system to improve stability:
- `IDRemapDeleteListener` is now only kept registered during `LoadGame`.
- Added two mutexes, one for changedIDs and one for deletedIDs, plus applicable lock guards.
- Added an atomic bool that keeps track of whether `IDRemapDeleteListener` is currently registered.